### PR TITLE
Update InfluxDB2 to v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ https://github.com/Jays-Home-Assistant-Add-ons/repository
 
 ### &#10003; [InfluxDB2][influxdb2-addon]
 
-![Latest Version][influxdb2-version-shield]
+![Latest Version][influxdb2-releases-shield]
+![Supports amd64 Architecture][influxdb2-amd64-shield]
+![Supports aarch64 Architecture][influxdb2-aarch64-shield]
 ![Supports armhf Architecture][influxdb2-armhf-shield]
 ![Supports armv7 Architecture][influxdb2-armv7-shield]
-![Supports aarch64 Architecture][influxdb2-aarch64-shield]
-![Supports amd64 Architecture][influxdb2-amd64-shield]
 ![Supports i386 Architecture][influxdb2-i386-shield]
 
 ![HA Ingress Support][influxdb2-ingressSupport]
@@ -58,13 +58,15 @@ If you're after InfluxDB v1.x [see here][influxdbv1]
 [influxdbv1]: https://github.com/hassio-addons/addon-influxdb
 [repositoryCommunity]: https://github.com/hassio-addons/repository
 
-[influxdb2-addon]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/tree/v1.0.0-beta1
-[influxdb2-version-shield]: https://img.shields.io/github/release/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
-[influxdb2-armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[influxdb2-armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[influxdb2-aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
-[influxdb2-amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[influxdb2-i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
-[influxdb2-doc]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/blob/v1.0.0-beta1/README.md
+[comment]: <> (-- INFLUXDB2 --)
+[influxdb2-releases-shield]: https://img.shields.io/github/release/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
 [influxdb2-local-build]: https://img.shields.io/badge/Home%20Assistant%20--%20local%20build-YES-orange.svg
 [influxdb2-ingressSupport]: https://img.shields.io/badge/Home%20Assistant%20--%20ingress%20support-NO-red
+[influxdb2-aarch64-shield]: https://img.shields.io/badge/aarch64-untested-orange.svg
+[influxdb2-amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
+[influxdb2-armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
+[influxdb2-armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
+[influxdb2-i386-shield]: https://img.shields.io/badge/i386-no-red.svg
+
+[influxdb2-doc]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/blob/main/README.md
+[influxdb2-addon]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2

--- a/influxdb2/CHANGELOG.md
+++ b/influxdb2/CHANGELOG.md
@@ -1,6 +1,9 @@
-## What’s changed
+## v1 Branch Changes
 
+- v1.0.1 - Release including updates to compatibility as InfluxDB only releases a AMD64 and ARM64 .deb file
 - V1.0.0-BETA1 - Initial Release
+
+## What’s changed - Release v1.0.1
 
 ## 🚀 Enhancements
 
@@ -8,7 +11,7 @@
 
 ## 🧰 Maintenance
 
-- Nill
+- Updates to compatibility as InfluxDB only releases a AMD64 and ARM64 .deb file
 
 ## ⬆️ Dependency updates
 

--- a/influxdb2/DOCS.md
+++ b/influxdb2/DOCS.md
@@ -193,7 +193,7 @@ Full details of the Home Assistant integration can be found here:
 
 ## Known issues and limitations
 
-- Nill
+- InfluxDB2 only supports x64 architecture
 
 
 ## Changelog & Releases

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -12,7 +12,6 @@ RUN \
     apt-get update \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
-    && if [ "${BUILD_ARCH}" = "armv7" ]; then ARCH="armhf"; fi \
     \
     && INFLUXDB="2.1.1" \
     && curl -J -L -o /tmp/influxdb2.deb \

--- a/influxdb2/README.md
+++ b/influxdb2/README.md
@@ -1,20 +1,20 @@
 # Jay's Home Assistant Add-ons: InfluxDB2
 
-![HA Ingress Support][ingressSupport]
+![HA Ingress Support][influxdb2-ingressSupport]
 ![Local Build][influxdb2-local-build]
 
-[![GitHub Release][releases-shield]][releases]
-![Project Stage][project-stage-shield]
-[![License][license-shield]](LICENSE.md)
+[![GitHub Release][influxdb2-releases-shield]][releases]
+![Project Stage][influxdb2-project-stage-shield]
+[![License][influxdb2-license-shield]](LICENSE.md)
 
-![Supports aarch64 Architecture][aarch64-shield]
-![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
+![Supports amd64 Architecture][influxdb2-amd64-shield]
+![Supports aarch64 Architecture][influxdb2-aarch64-shield]
+![Supports armhf Architecture][influxdb2-armhf-shield]
+![Supports armv7 Architecture][influxdb2-armv7-shield]
+![Supports i386 Architecture][influxdb2-i386-shield]
 
-![Project Maintenance][maintenance-shield]
-[![GitHub Activity][commits-shield]][commits]
+![Project Maintenance][influxdb2-maintenance-shield]
+[![GitHub Activity][influxdb2-commits-shield]][commits]
 
 
 Scalable datastore for metrics, events, and real-time analytics.
@@ -102,25 +102,25 @@ SOFTWARE.
 
 [influxdb2-local-build]: https://img.shields.io/badge/Home%20Assistant%20--%20local%20build-YES-orange.svg
 [releases]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/releases
-[releases-shield]: https://img.shields.io/github/release/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
-[aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
-[amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
-[commits-shield]: https://img.shields.io/github/commit-activity/y/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
+[influxdb2-releases-shield]: https://img.shields.io/github/release/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
+[influxdb2-aarch64-shield]: https://img.shields.io/badge/aarch64-untested-orange.svg
+[influxdb2-amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
+[influxdb2-armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
+[influxdb2-armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
+[influxdb2-i386-shield]: https://img.shields.io/badge/i386-no-red.svg
+[influxdb2-commits-shield]: https://img.shields.io/github/commit-activity/y/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
 [commits]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/commits/main
 [contributors]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/graphs/contributors
 [docs]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/blob/main/influxdb2/DOCS.md
 [frenck]: https://github.com/frenck
 [jantoney]: https://github.com/jantoney
 [issue]: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2/issues
-[license-shield]: https://img.shields.io/github/license/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2022.svg
-[project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
+[influxdb2-license-shield]: https://img.shields.io/github/license/Jays-Home-Assistant-Add-ons/j-addon-influxdb2.svg
+[influxdb2-maintenance-shield]: https://img.shields.io/maintenance/yes/2022.svg
+[influxdb2-project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [reddit]: https://reddit.com/r/homeassistant
 [repositoryMe]: https://github.com/Jays-Home-Assistant-Add-ons/repository
 [Influxdbv1]: https://github.com/hassio-addons/addon-influxdb
 [githubDiscussions]: https://github.com/hassio-addons/addon-influxdb/discussions
 [repositoryCommunity]: https://github.com/hassio-addons/repository
-[ingressSupport]: https://img.shields.io/badge/Home%20Assistant%20--%20ingress%20support-NO-red
+[influxdb2-ingressSupport]: https://img.shields.io/badge/Home%20Assistant%20--%20ingress%20support-NO-red

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: InfluxDB2
-version: 1.0.0
+version: 1.0.1
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2
@@ -11,8 +11,6 @@ hassio_api: true
 arch:
   - aarch64
   - amd64
-  - armv7
-  - i386
 init: false
 map:
   - share:rw


### PR DESCRIPTION
Updates to architecture compatibility as InfluxDB2 only releases a AMD64 and ARM64 .deb file